### PR TITLE
Converted CreaturePackObj to ES6 Class

### DIFF
--- a/Phaser3/Phaser3BasicGroup.html
+++ b/Phaser3/Phaser3BasicGroup.html
@@ -49,29 +49,25 @@
         this.cameras.main.backgroundColor.setTo(50,50,50);
 
         horse_char = new CreaturePackObj(this, 790, 390, this.cache.binary.get('horse_char'), 'horse_texture');
-        horse_char.mesh.modelScale.x = 0.1;
-        horse_char.mesh.modelScale.y = 0.1;
+        horse_char.modelScale.x = 0.1;
+        horse_char.modelScale.y = 0.1;
 
         horse_char.speed = 0.06;
         horse_char.pack_renderer.blendToAnimation("run", 0.1);
 
         creature_char = new CreaturePackObj(this, 380, 450, this.cache.binary.get('char'), 'texture');
-        creature_char.mesh.modelScale.x = 0.07;
-        creature_char.mesh.modelScale.y = 0.07;
+        creature_char.modelScale.x = 0.07;
+        creature_char.modelScale.y = 0.07;
 
         bat_char = new CreaturePackObj(this, 330, 300, this.cache.binary.get('bat_char'), 'bat_texture');
-        bat_char.mesh.modelScale.x = 0.1;
-        bat_char.mesh.modelScale.y = 0.1;
+        bat_char.modelScale.x = 0.1;
+        bat_char.modelScale.y = 0.1;
 
         bat_char.speed = 0.1;
     }
 
     function update (time, delta)
     {
-        horse_char.tick(time, delta);
-        creature_char.tick(time, delta);
-        bat_char.tick(time, delta);
-
         frame_cnt++;
         if(frame_cnt % 150 == 0)
         {

--- a/Phaser3/Phaser3BasicSample.html
+++ b/Phaser3/Phaser3BasicSample.html
@@ -42,15 +42,12 @@
         this.add.text(10, 0, 'CreaturePack Runtimes for Phaser 3', { fontFamily: '"Roboto Condensed"', fontSize: 32, color: '#FFFF00'  });
         this.cameras.main.backgroundColor.setTo(50,50,50);
         creature_char = new CreaturePackObj(this, 400, 300, this.cache.binary.get('char'), 'texture');
-        // To access the mesh ( which is a Phaser 3 object, use creature_char.mesh )
-        creature_char.mesh.modelScale.x = 0.1;
-        creature_char.mesh.modelScale.y = 0.1;
+        creature_char.modelScale.x = 0.1;
+        creature_char.modelScale.y = 0.1;
     }
 
     function update (time, delta)
     {
-        creature_char.tick(time, delta);
-
         frame_cnt++;
         if(frame_cnt % 150 == 0)
         {

--- a/Phaser3/Phaser3Composer.html
+++ b/Phaser3/Phaser3Composer.html
@@ -22,7 +22,6 @@
         scene: {
             preload: preload,
             create: create,
-            update: update
         }
     };
 
@@ -43,16 +42,8 @@
 
         // Load our CreaturePack character
         creature_char = new CreaturePackObj(this, 480, 300, this.cache.binary.get('char'), 'texture');
-        // To access the mesh ( which is a Phaser 3 object, use creature_char.mesh )
-        // Here we setup the character size by tweaking the modelScale on the mesh object
-        creature_char.mesh.modelScale.x = 0.3;
-        creature_char.mesh.modelScale.y = 0.3;
-    }
-
-    function update (time, delta)
-    {
-        // We tick the Creature character to update its animation state
-        creature_char.tick(time, delta);
+        creature_char.modelScale.x = 0.3;
+        creature_char.modelScale.y = 0.3;
     }
     </script>
 

--- a/Phaser3/Phaser3Flamingo.html
+++ b/Phaser3/Phaser3Flamingo.html
@@ -22,7 +22,6 @@
         scene: {
             preload: preload,
             create: create,
-            update: update
         }
     };
 
@@ -51,17 +50,11 @@
         creature_char = new CreaturePackObj(this, 400, 300, this.cache.binary.get('char'), 'texture');
         // To access the mesh ( which is a Phaser 3 object, use creature_char.mesh )
         // Here we setup the character size by tweaking the modelScale on the mesh object
-        creature_char.mesh.modelScale.x = 0.1;
-        creature_char.mesh.modelScale.y = 0.1;
+        creature_char.modelScale.x = 0.1;
+        creature_char.modelScale.y = 0.1;
 
         // Set character animation clip
         creature_char.pack_renderer.setActiveAnimation("walk");
-    }
-
-    function update (time, delta)
-    {
-        // We tick the Creature character to update its animation state
-        creature_char.tick(time, delta);
     }
     </script>
 


### PR DESCRIPTION
1. Converted CreaturePackObj to ES6 Class
2. Extends Phaser.GameObjects.Mesh and use built-in preUpdate method to replace tick method.